### PR TITLE
workspace: track current time alongside current frame in PlaybackState

### DIFF
--- a/src/vsview/app/settings/models.py
+++ b/src/vsview/app/settings/models.py
@@ -8,7 +8,7 @@ from abc import ABC, ABCMeta, abstractmethod
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from contextlib import contextmanager, suppress
 from dataclasses import KW_ONLY, dataclass, field
-from datetime import time
+from datetime import time, timedelta
 from enum import StrEnum
 from functools import wraps
 from logging import getLogger
@@ -1518,6 +1518,7 @@ class LocalSettings(BaseSettings):
 
     source_path: str = ""
     last_frame: int = 0
+    last_time: timedelta = timedelta()
     last_output_tab_index: Annotated[int, AfterValidator(lambda i: max(0, i))] = 0
     playback: LocalPlaybackSettings = Field(default_factory=lambda: LocalPlaybackSettings())
     timeline: LocalTimelineSettings = Field(default_factory=lambda: LocalTimelineSettings())

--- a/src/vsview/app/workspace/file.py
+++ b/src/vsview/app/workspace/file.py
@@ -22,6 +22,7 @@ from ...vsenv import run_in_loop
 from ..plugins.manager import PluginManager
 from ..settings import SettingsManager
 from ..settings.models import LocalSettings
+from ..views.timeline import Time
 from .loader import LoaderWorkspace, VSEngineWorkspace
 
 logger = getLogger(__name__)
@@ -167,7 +168,7 @@ class GenericFileWorkspace(LoaderWorkspace[Path]):
         self.local_settings.layout.plugin_tab_index = self.plugin_splitter.plugin_tabs.currentIndex()
         self.local_settings.layout.dock_state = b64encode(self.dock_container.saveState().data()).decode("ascii")
 
-    def init_load(self, frame: int | None = None, tab_index: int | None = None) -> None:
+    def init_load(self, frame: int | None = None, time: float | None = None, tab_index: int | None = None) -> None:
         self.tab_manager.sync_playhead_btn.set_state(state=self.local_settings.synchronization.sync_playhead)
         self.tab_manager.sync_zoom_btn.setChecked(self.local_settings.synchronization.sync_zoom)
         self.tab_manager.sync_scroll_btn.setChecked(self.local_settings.synchronization.sync_scroll)
@@ -190,6 +191,8 @@ class GenericFileWorkspace(LoaderWorkspace[Path]):
 
         if frame is None:
             self.playback.state.current_frame = self.local_settings.last_frame
+        if time is None:
+            self.playback.state.current_time = Time(self.local_settings.last_time.total_seconds())
 
         if tab_index is None:
             self.outputs_manager.current_video_index = self.local_settings.last_output_tab_index
@@ -200,9 +203,16 @@ class GenericFileWorkspace(LoaderWorkspace[Path]):
     def get_output_metadata(self) -> dict[int, Any]:
         return output_metadata.get(str(self.content), {})
 
-    def load_content(self, content: Path, /, frame: int | None = None, tab_index: int | None = None) -> Future[None]:
+    def load_content(
+        self,
+        content: Path,
+        /,
+        frame: int | None = None,
+        time: float | None = None,
+        tab_index: int | None = None,
+    ) -> Future[None]:
         with self._restart_autosave():
-            return super().load_content(content, frame, tab_index)
+            return super().load_content(content, frame, time, tab_index)
 
     def reload_content(self) -> Future[None]:
         with self._restart_autosave():

--- a/src/vsview/app/workspace/file.py
+++ b/src/vsview/app/workspace/file.py
@@ -141,6 +141,7 @@ class GenericFileWorkspace(LoaderWorkspace[Path]):
     @requires_content
     def snapshot_settings(self) -> None:
         self.local_settings.last_frame = self.playback.state.current_frame
+        self.local_settings.last_time = self.playback.state.current_time
         self.local_settings.last_output_tab_index = self.tab_manager.tabs.currentIndex()
         self.local_settings.synchronization.sync_playhead = self.tab_manager.sync_playhead_state
         self.local_settings.synchronization.sync_zoom = self.tab_manager.is_sync_zoom_enabled

--- a/src/vsview/app/workspace/loader.py
+++ b/src/vsview/app/workspace/loader.py
@@ -647,20 +647,8 @@ class LoaderWorkspace[T](BaseWorkspace):
                 logger.debug("Sync playhead %r, using last frame %d", s, target_frame)
                 return target_frame
             case PlayHeadToolButton.State.LINK_TIME:
-                src_fps = self.outputs_manager.voutputs[self.tab_manager.tabs.previous_tab_index]
-                tgt_fps = self.outputs_manager.current_voutput
-
-                current_time = self.outputs_manager.current_voutput.frame_to_time(
-                    self.playback.state.current_frame,
-                    src_fps,
-                )
-                target_frame = self.outputs_manager.current_voutput.time_to_frame(
-                    current_time,
-                    tgt_fps,
-                )
-
                 target_frame = clamp(
-                    target_frame,
+                    self.outputs_manager.current_voutput.time_to_frame(self.playback.state.current_time),
                     0,
                     self.outputs_manager.current_voutput.vs_output.clip.num_frames - 1,
                 )
@@ -669,7 +657,7 @@ class LoaderWorkspace[T](BaseWorkspace):
                     "Sync playhead %r, targeting frame %d (from time %.3fs)",
                     s,
                     target_frame,
-                    current_time.total_seconds(),
+                    self.playback.state.current_time.total_seconds(),
                 )
                 return target_frame
             case PlayHeadToolButton.State.LINK_FRAME:

--- a/src/vsview/app/workspace/loader.py
+++ b/src/vsview/app/workspace/loader.py
@@ -281,11 +281,18 @@ class LoaderWorkspace[T](BaseWorkspace):
     @abstractmethod
     def loader(self) -> None: ...
 
-    def init_load(self, frame: int | None = None, tab_index: int | None = None) -> None:
+    def init_load(self, frame: int | None = None, time: float | None = None, tab_index: int | None = None) -> None:
         PluginManager.wait_for_loaded()
 
     @run_in_background(name="LoadContent")
-    def load_content(self, content: T, /, frame: int | None = None, tab_index: int | None = None) -> None:
+    def load_content(
+        self,
+        content: T,
+        /,
+        frame: int | None = None,
+        time: float | None = None,
+        tab_index: int | None = None,
+    ) -> None:
         logger.debug("load_content called: path=%r, frame=%r, tab_index=%r", content, frame, tab_index)
 
         self.set_loading_page()
@@ -294,7 +301,7 @@ class LoaderWorkspace[T](BaseWorkspace):
         self.content = content
 
         unset_environment()
-        self.init_load(frame, tab_index)
+        self.init_load(frame, time, tab_index)
 
         with loader_lock:
             outputs = self._get_outputs()

--- a/src/vsview/app/workspace/playback.py
+++ b/src/vsview/app/workspace/playback.py
@@ -62,6 +62,7 @@ class PlaybackState(QObject):
         super().__init__(parent)
 
         self.current_frame = 0
+        self.current_time = Time()
         self.is_playing = False
 
         self.last_fps_update_ns = 0
@@ -235,6 +236,7 @@ class PlaybackManager(QObject):
             elif self._tab_manager.tabs.currentIndex() != -1:
                 voutput.last_frame = n
                 self.state.current_frame = n
+                self.state.current_time = voutput.frame_to_time(n)
 
             if cb_render:
                 cb_render(f)
@@ -458,6 +460,7 @@ class PlaybackManager(QObject):
                 self._track_fps()
 
                 self.state.current_frame = frame_n
+                self.state.current_time = voutput.frame_to_time(frame_n)
                 voutput.last_frame = frame_n
 
                 try:

--- a/src/vsview/app/workspace/quick_script.py
+++ b/src/vsview/app/workspace/quick_script.py
@@ -459,6 +459,7 @@ class QuickScriptWorkspace(VSEngineWorkspace[CodeContent]):
             return self.load_content(
                 self.content,
                 self.playback.state.current_frame,
+                self.playback.state.current_time.total_seconds(),
                 self.outputs_manager.current_video_index,
             )
 


### PR DESCRIPTION
- Fixes #84 where the current time was computed from the same output and discarded all informations from the last session.
- Persist last playback time in settings and expose the `time` parameter in `LoaderWorkspace.init_load` `LoaderWorkspace.load_content`. This is pretty much dead code since nothing is using it at the moment.