### PR TITLE
workspace: implement jump to time and frame shortcuts

### DIFF
--- a/src/vsview/app/settings/action.py
+++ b/src/vsview/app/settings/action.py
@@ -65,6 +65,8 @@ class ActionID(StrEnum):
     SEEK_N_FRAMES_FORWARD = "workspace.loader.timeline.seek_n_frames_forward", "Seek N Frames Forward", "Shift+Right"
     SEEK_FIRST_FRAME = "workspace.loader.timeline.seek_first_frame", "Seek First Frame", ""
     SEEK_LAST_FRAME = "workspace.loader.timeline.seek_last_frame", "Seek Last Frame", ""
+    JUMP_TO_TIME = "workspace.loader.timeline.jump_to_time", "Jump to Time", "Ctrl+F"
+    JUMP_TO_FRAME = "workspace.loader.timeline.jump_to_frame", "Jump to Frame", "Ctrl+G"
 
     # Tab switching
     SWITCH_TAB_0 = "workspace.loader.tab.switch_0", "Switch to Output 0", "1"

--- a/src/vsview/app/views/timeline.py
+++ b/src/vsview/app/views/timeline.py
@@ -11,7 +11,21 @@ from math import floor
 from typing import Any, Literal, NamedTuple, override
 
 from jetpytools import clamp, complex_hash
-from PySide6.QtCore import QEvent, QLineF, QPoint, QPointF, QRectF, QSignalBlocker, QSize, Qt, QTime, Signal
+from PySide6.QtCore import (
+    QEasingCurve,
+    QEvent,
+    QLineF,
+    QPoint,
+    QPointF,
+    QPropertyAnimation,
+    QRectF,
+    QSequentialAnimationGroup,
+    QSignalBlocker,
+    QSize,
+    Qt,
+    QTime,
+    Signal,
+)
 from PySide6.QtGui import (
     QColor,
     QContextMenuEvent,
@@ -31,10 +45,12 @@ from PySide6.QtGui import (
     QValidator,
 )
 from PySide6.QtWidgets import (
+    QAbstractSpinBox,
     QCheckBox,
     QComboBox,
     QDoubleSpinBox,
     QFormLayout,
+    QGraphicsDropShadowEffect,
     QHBoxLayout,
     QLabel,
     QMenu,
@@ -1017,6 +1033,38 @@ class Timeline(QWidget):
         self.mode = "frame" if index == 0 else "time"
 
 
+def _show_focus_for_user(self: QAbstractSpinBox) -> None:
+    self.setFocus()
+    self.selectAll()
+
+    accent = self.palette().color(QPalette.ColorRole.Accent)
+    effect = QGraphicsDropShadowEffect(self)
+    effect.setBlurRadius(0)
+    effect.setColor(accent)
+    effect.setOffset(0, 0)
+    self.setGraphicsEffect(effect)
+
+    # Ramp up: fast
+    anim_in = QPropertyAnimation(effect, b"blurRadius", self)
+    anim_in.setDuration(200)
+    anim_in.setStartValue(0.0)
+    anim_in.setEndValue(50.0)
+    anim_in.setEasingCurve(QEasingCurve.Type.OutCubic)
+
+    # Decay: slow fade
+    anim_out = QPropertyAnimation(effect, b"blurRadius", self)
+    anim_out.setDuration(800)
+    anim_out.setStartValue(50.0)
+    anim_out.setEndValue(0.0)
+    anim_out.setEasingCurve(QEasingCurve.Type.InCubic)
+
+    group = QSequentialAnimationGroup(self)
+    group.addAnimation(anim_in)
+    group.addAnimation(anim_out)
+    group.finished.connect(effect.deleteLater)
+    group.start()
+
+
 class FrameEdit(QSpinBox):
     frameChanged = Signal(Frame, Frame)
 
@@ -1040,6 +1088,8 @@ class FrameEdit(QSpinBox):
 
         return super().validate(input_text, pos)
 
+    show_focus_for_user = _show_focus_for_user
+
     def _on_value_changed(self, value: int) -> None:
         self.frameChanged.emit(Frame(value), Frame(self.old_value))
         self.old_value = value
@@ -1058,6 +1108,8 @@ class TimeEdit(QTimeEdit):
         self.setKeyboardTracking(False)
 
         self.old_time = self.time()
+
+    show_focus_for_user = _show_focus_for_user
 
     def _on_time_changed(self, value: QTime) -> None:
         self.valueChanged.emit(self.time(), self.old_time)

--- a/src/vsview/app/workspace/loader.py
+++ b/src/vsview/app/workspace/loader.py
@@ -219,6 +219,17 @@ class LoaderWorkspace[T](BaseWorkspace):
             lambda: self.playback.request_frame(0x7FFFFFFF),
             self.loaded_page,
         )
+        sm.register_shortcut(
+            ActionID.JUMP_TO_TIME,
+            self.tbar.playback_container.time_edit.show_focus_for_user,
+            self.loaded_page,
+        )
+        sm.register_shortcut(
+            ActionID.JUMP_TO_FRAME,
+            self.tbar.playback_container.frame_edit.show_focus_for_user,
+            self.loaded_page,
+        )
+
         sm.register_shortcut(ActionID.RELOAD, self.reload_content, self.loaded_page)
         sm.register_shortcut(ActionID.RELOAD, self.reload_btn.click, self.error_page)
         sm.register_shortcut(ActionID.COPY_CURRENT_FRAME, self._copy_current_frame_to_clipboard, self.loaded_page)


### PR DESCRIPTION
Instead of duplicating widgets and functionality, the Jump To feature is implemented by changing focus to the target widget and using an animation to visually indicate the focus transition to the user.

The default keyboard shortcuts are:
- Ctrl+F: Focus the timeline edit.
- Ctrl+G: Focus the frame edit.