### PR TITLE
comp: implement browser ID persistence

### DIFF
--- a/src/plugins/comp/src/vsview_comp/plugin.py
+++ b/src/plugins/comp/src/vsview_comp/plugin.py
@@ -5,8 +5,9 @@ from functools import cache
 from logging import getLogger
 from pathlib import Path
 from typing import Annotated, Any, override
+from uuid import uuid4
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from PySide6.QtCore import QEvent, QObject, QSignalBlocker, Qt, QTime, QTimer
 from PySide6.QtGui import QCursor
 from PySide6.QtWidgets import (
@@ -53,6 +54,7 @@ from vsview.api import (
 from ._metadata import LOGIN_CONTEXT, PLUGIN_DISPLAY, PLUGIN_ID
 from .models import ComparisonImage, ComparisonSource, TMDBTitle
 from .ui import (
+    BrowserID,
     FrameSourceProvider,
     FrameThumbnailList,
     LineEditCompleter,
@@ -70,6 +72,17 @@ logger = getLogger(__name__)
 
 
 class GlobalSettings(BaseModel):
+    browser_id: Annotated[
+        str,
+        BrowserID(
+            label="Browser ID",
+            tooltip=(
+                "This browser ID identifies your uploads on slow.pics. "
+                "Copy it to your browser cookies to claim comparisons."
+            ),
+        ),
+    ] = Field(default_factory=lambda: str(uuid4()))
+
     tmdb_format: Annotated[
         str,
         LineEditCompleter(
@@ -159,7 +172,7 @@ class CompPlugin(WidgetPluginBase[GlobalSettings, None], IconReloadMixin):
 
         main_layout.addWidget(self.progress_stack)
 
-        self.slowpics_worker = SlowPicsWorker(self.api, self.secrets, self.progress_bar)
+        self.slowpics_worker = SlowPicsWorker(self.api, self.settings, self.secrets, self.progress_bar)
 
         self.api.register_action(
             f"{PLUGIN_ID}.add_current_frame",

--- a/src/plugins/comp/src/vsview_comp/ui.py
+++ b/src/plugins/comp/src/vsview_comp/ui.py
@@ -10,11 +10,12 @@ from functools import partial
 from logging import getLogger
 from pathlib import Path
 from typing import Any, NamedTuple, Self, override
+from uuid import uuid4
 
 import jinja2
 from jetpytools import cachedproperty
 from PySide6.QtCore import QBuffer, QCoreApplication, QEvent, QIODevice, QObject, QPoint, QRect, QSize, Qt, Signal
-from PySide6.QtGui import QIcon, QImage, QKeyEvent, QMouseEvent, QPainter, QPaintEvent, QPixmap, QWheelEvent
+from PySide6.QtGui import QCursor, QIcon, QImage, QKeyEvent, QMouseEvent, QPainter, QPaintEvent, QPixmap, QWheelEvent
 from PySide6.QtNetwork import QNetworkAccessManager, QNetworkReply, QNetworkRequest
 from PySide6.QtWidgets import (
     QAbstractItemView,
@@ -37,6 +38,7 @@ from PySide6.QtWidgets import (
     QStyle,
     QStyleOptionFrame,
     QToolButton,
+    QToolTip,
     QVBoxLayout,
     QWidget,
     QWidgetAction,
@@ -46,7 +48,18 @@ from shiboken6 import Shiboken
 from vapoursynth import VideoFrame, VideoNode
 from vstools import core, get_prop
 
-from vsview.api import LineEdit, NonClosingMenu, PluginAPI, Time, VideoOutputProxy, run_in_background, run_in_loop
+from vsview.api import (
+    IconName,
+    IconReloadMixin,
+    LineEdit,
+    NonClosingMenu,
+    PluginAPI,
+    Time,
+    VideoOutputProxy,
+    WidgetMetadata,
+    run_in_background,
+    run_in_loop,
+)
 
 from .models import TMDBTitle
 
@@ -1085,3 +1098,62 @@ class LineEditCompleter(LineEdit):
     @override
     def create_widget(self, parent: QWidget | None = None) -> QLineEdit:
         return PlaceholderLineEdit([*TMDBTitle.format_hints, "vs_names"], parent)
+
+
+class BrowserIDWidget(QWidget, IconReloadMixin):
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        self.browser_id_lbl = QLabel(self)
+        self.browser_id_lbl.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
+        self.browser_id_lbl.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
+        self.browser_id_lbl.setStyleSheet("""
+            border: 1px solid palette(mid);
+            border-radius: 4px;
+            padding: 4px;
+            background: palette(button);
+        """)
+
+        self.regenerate_id_btn = self.make_tool_button(IconName.ARROW_CLOCKWISE, "Generate a new browser ID", self)
+        self.regenerate_id_btn.clicked.connect(self.on_regenerate_id_btn_clicked)
+
+        self.copy_btn = self.make_tool_button(IconName.CLIPBOARD, "Copy browser ID", self)
+        self.copy_btn.clicked.connect(self.on_copy_btn_clicked)
+
+        layout.addWidget(self.browser_id_lbl)
+        layout.addWidget(self.regenerate_id_btn)
+        layout.addWidget(self.copy_btn)
+
+    @property
+    def id(self) -> str:
+        return self.browser_id_lbl.text()
+
+    @id.setter
+    def id(self, value: str) -> None:
+        self.browser_id_lbl.setText(value)
+
+    def on_regenerate_id_btn_clicked(self) -> None:
+        self.id = str(uuid4())
+
+    def on_copy_btn_clicked(self) -> None:
+        QApplication.clipboard().setText(self.browser_id_lbl.text())
+        QToolTip.showText(QCursor.pos(), "Copied!", self.copy_btn)
+
+
+class BrowserID(WidgetMetadata[BrowserIDWidget]):
+    @override
+    def create_widget(self, parent: QWidget | None = None) -> BrowserIDWidget:
+        return BrowserIDWidget(parent)
+
+    @override
+    def load_value(self, widget: BrowserIDWidget, value: Any) -> None:
+        with self.apply_transform(value, self.to_ui) as value:
+            widget.id = value
+
+    @override
+    def get_value(self, widget: BrowserIDWidget) -> Any:
+        with self.apply_transform(widget.id, self.from_ui) as value:
+            return value

--- a/src/plugins/comp/src/vsview_comp/worker.py
+++ b/src/plugins/comp/src/vsview_comp/worker.py
@@ -13,7 +13,6 @@ from logging import getLogger
 from operator import attrgetter
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple
-from uuid import uuid4
 
 import anyio
 import niquests
@@ -25,7 +24,7 @@ from PySide6.QtGui import QImage
 from vapoursynth import GRAY8, VideoNode
 from vstools import DitherType, clip_data_gather, core, depth, get_prop, remap_frames
 
-from vsview.api import Packer, PluginAPI, PluginSecrets, Time, run_in_background
+from vsview.api import Packer, PluginAPI, PluginSecrets, PluginSettings, Time, run_in_background
 
 from ._metadata import COOKIE_KEY, LOGIN_CONTEXT
 from .models import ComparisonSource, TMDBPayload, TMDBTitle, TMDBTitleData
@@ -33,7 +32,7 @@ from .ui import FrameSourceProvider, ProgressBar
 from .utils import LogNiquestsErrors, get_random_number_interval, get_slowpics_headers
 
 if TYPE_CHECKING:
-    from .plugin import CompPlugin
+    from .plugin import CompPlugin, GlobalSettings
 
 REV_CONF = niquests.RevocationConfiguration(niquests.RevocationStrategy.PREFER_CRL)
 
@@ -390,11 +389,17 @@ class SlowPicsWorker:
     BASE_URL = "https://slow.pics"
     MAX_CONCURRENT_REQUESTS = 6
 
-    def __init__(self, api: PluginAPI, secrets: PluginSecrets, progress_bar: ProgressBar) -> None:
+    def __init__(
+        self,
+        api: PluginAPI,
+        settings: PluginSettings[GlobalSettings, None],
+        secrets: PluginSecrets,
+        progress_bar: ProgressBar,
+    ) -> None:
         self.api = api
+        self.settings = settings
         self.secrets = secrets
         self.progress_bar = progress_bar
-        self.browser_id = str(uuid4())
         self.headers = get_slowpics_headers()
 
     @run_in_background(name="SlowPicsTags")
@@ -468,7 +473,7 @@ class SlowPicsWorker:
 
             payload = {
                 "collectionName": collection_name or "",
-                "browserId": self.browser_id,
+                "browserId": self.settings.global_.browser_id,
                 "optimizeImages": "true",
                 "desiredFileType": "image/png",
                 "hentai": str(nsfw).lower(),
@@ -536,9 +541,12 @@ class SlowPicsWorker:
         homepage.raise_for_status()
 
         if not (browser_id := self._get_cookie(client.cookies, "BROWSER-ID")):
-            niquests.cookies.cookiejar_from_dict({"BROWSER-ID": self.browser_id}, cookiejar=client.cookies)
+            niquests.cookies.cookiejar_from_dict(
+                {"BROWSER-ID": self.settings.global_.browser_id},
+                cookiejar=client.cookies,
+            )
         else:
-            self.browser_id = browser_id
+            self.settings.global_.browser_id = browser_id
 
         client.headers.update({"X-XSRF-TOKEN": self._get_cookie(client.cookies, "XSRF-TOKEN")})
 
@@ -600,7 +608,7 @@ class SlowPicsWorker:
         image_path: Path,
     ) -> None:
         url = f"/upload/image/{image_uuid}"
-        data = {"collectionUuid": collection, "imageUuid": image_uuid, "browserId": self.browser_id}
+        data = {"collectionUuid": collection, "imageUuid": image_uuid, "browserId": self.settings.global_.browser_id}
 
         # Handle 429 "Too many requests"
         for retry in range(5):


### PR DESCRIPTION
Add a new setting to manage the browser ID used for identifying uploads on slow.pics. This allows users to manually regenerate or copy their ID to claim comparisons via browser cookies.