### PR TITLE
comp: add support for uploads and operation cancellation

### DIFF
--- a/src/plugins/comp/pyproject.toml
+++ b/src/plugins/comp/pyproject.toml
@@ -30,7 +30,6 @@ classifiers = [
 dependencies = [
     "vsview[secrets]>=0.4.0",
     "vsjetpack>=1.5.0",
-    "anyio>=4.12.1",
     "pathvalidate>=3.3.1",
     "jinja2>=3.1.6",
     "niquests>=3.19.0",

--- a/src/plugins/comp/src/vsview_comp/models.py
+++ b/src/plugins/comp/src/vsview_comp/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from logging import getLogger
 from pathlib import Path
 from typing import Any, Literal, NamedTuple, Self
@@ -22,6 +22,77 @@ class ComparisonImage(NamedTuple):
 class ComparisonSource(NamedTuple):
     name: str
     images: Sequence[ComparisonImage]
+
+
+class SlowPicsSources(NamedTuple):
+    collection_name: str
+    sources: Sequence[ComparisonSource]
+    public: bool
+    nsfw: bool
+    tmdb_id: str | None
+    remove_after: int
+    tags: list[str]
+
+    @property
+    def is_comparison(self) -> bool:
+        return len(self.sources) > 1
+
+    @property
+    def upload_type(self) -> str:
+        return "comparison" if self.is_comparison else "collection"
+
+    @property
+    def total_images(self) -> int:
+        return sum(len(images) for _, images in self.sources)
+
+    @property
+    def payload(self) -> dict[str, str]:
+        payload = {
+            "collectionName": self.collection_name or "",
+            "optimizeImages": "true",
+            "desiredFileType": "image/png",
+            "hentai": str(self.nsfw).lower(),
+            "public": str(self.public).lower(),
+            "visibility": "PUBLIC" if self.public else "LINK_ONLY",
+            "removeAfter": str(self.remove_after) if self.remove_after >= 1 else "",
+        }
+
+        for j in range(len(self.sources[0].images)):
+            if self.is_comparison:
+                image_ref = self.sources[0][1][j]
+                payload[f"comparisons[{j}].name"] = f"{image_ref.timestamp} / {image_ref.frame_no}"
+                payload[f"comparisons[{j}].hentai"] = str(self.nsfw).lower()
+
+                for i, (source_name, images) in enumerate(self.sources):
+                    payload[f"comparisons[{j}].imageNames[{i}]"] = (
+                        f"{source_name}{f' ({images[j].pict_type})' if images[j].pict_type != '?' else ''}"
+                    )
+            else:
+                # Single source collection
+                source_name, images = self.sources[0]
+                image = images[j]
+                payload[f"imageNames[{j}]"] = f"{image.timestamp} / {image.frame_no} - {source_name}"
+
+        if self.public:
+            payload |= {f"tags[{i}]": tag for i, tag in enumerate(self.tags)}
+
+        if self.tmdb_id:
+            payload["tmdbId"] = self.tmdb_id
+
+        return payload
+
+    def get_images(self, comp_data: SlowPicsUploadResponse) -> Iterator[tuple[str, Path]]:
+        for i, (_, images) in enumerate(self.sources):
+            for j, (image_path, *_) in enumerate(images):
+                yield comp_data.images[j][i] if self.is_comparison else comp_data.images[0][j], image_path
+
+
+class SlowPicsUploadResponse(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    collection_uuid: str = Field(alias="collectionUuid")
+    key: str
+    images: list[list[str]]
 
 
 class TMDBGenre(BaseModel):

--- a/src/plugins/comp/src/vsview_comp/plugin.py
+++ b/src/plugins/comp/src/vsview_comp/plugin.py
@@ -1,6 +1,7 @@
 import ast
+import asyncio
 from collections.abc import Sequence
-from concurrent.futures import Future
+from concurrent.futures import CancelledError, Future
 from functools import cache
 from logging import getLogger
 from pathlib import Path
@@ -52,7 +53,7 @@ from vsview.api import (
 )
 
 from ._metadata import LOGIN_CONTEXT, PLUGIN_DISPLAY, PLUGIN_ID
-from .models import ComparisonImage, ComparisonSource, TMDBTitle
+from .models import ComparisonImage, ComparisonSource, SlowPicsSources, TMDBTitle
 from .ui import (
     BrowserID,
     FrameSourceProvider,
@@ -125,6 +126,9 @@ class CompPlugin(WidgetPluginBase[GlobalSettings, None], IconReloadMixin):
         self._pending_extract_frames: Future[list[tuple[int, Path]]] | None = None
         self._pending_upload: Future[str] | Future[None] | None = None
         self._pending_tags: Future[list[Tag]] | None = None
+        self._select_frames_worker: SelectFrameWorker | None = None
+        self._extract_frames_worker: ExtractFramesWorker | None = None
+        self._is_upload_cancelled = False
         self._extraction_finished = False
         self._extract_paths: list[tuple[int, Path]] | None = None
         self._reported_url = ""
@@ -147,8 +151,19 @@ class CompPlugin(WidgetPluginBase[GlobalSettings, None], IconReloadMixin):
         self.progress_stack = QStackedWidget(self)
         self.progress_stack.hide()
 
-        self.progress_bar = ProgressBar(self.progress_stack)
+        self.progress_container = QWidget(self.progress_stack)
+        progress_layout = QHBoxLayout(self.progress_container)
+        progress_layout.setContentsMargins(0, 0, 0, 0)
+        progress_layout.setSpacing(4)
+
+        self.progress_bar = ProgressBar(self.progress_container)
         self.progress_bar.progressRunning.connect(self.set_progress_bar_on_top)
+
+        self.cancel_btn = self.make_tool_button(IconName.X_CIRCLE, "Cancel operation", self.progress_container)
+        self.cancel_btn.clicked.connect(self.on_cancel_clicked)
+
+        progress_layout.addWidget(self.progress_bar, 1)
+        progress_layout.addWidget(self.cancel_btn)
 
         self.reported_url_container = QWidget(self.progress_stack)
         reported_url_layout = QHBoxLayout(self.reported_url_container)
@@ -166,9 +181,9 @@ class CompPlugin(WidgetPluginBase[GlobalSettings, None], IconReloadMixin):
         reported_url_layout.addWidget(self.url_label)
         reported_url_layout.addWidget(self.url_copy_btn)
 
-        self.progress_stack.addWidget(self.progress_bar)
+        self.progress_stack.addWidget(self.progress_container)
         self.progress_stack.addWidget(self.reported_url_container)
-        self.progress_stack.setCurrentWidget(self.progress_bar)
+        self.progress_stack.setCurrentWidget(self.progress_container)
 
         main_layout.addWidget(self.progress_stack)
 
@@ -559,7 +574,7 @@ class CompPlugin(WidgetPluginBase[GlobalSettings, None], IconReloadMixin):
         self.frames_list.update_thumbnails(voutput.vs_index)
 
     def set_progress_bar_on_top(self) -> None:
-        self.progress_stack.setCurrentWidget(self.progress_bar)
+        self.progress_stack.setCurrentWidget(self.progress_container)
         self.progress_stack.show()
 
     def set_url_on_top(self) -> None:
@@ -648,8 +663,17 @@ class CompPlugin(WidgetPluginBase[GlobalSettings, None], IconReloadMixin):
         @run_in_loop
         def on_finished(future: Future[list[tuple[Time, FrameSourceProvider]]]) -> None:
             self.progress_bar.reset_progress()
+            self.progress_stack.hide()
 
-            if future.exception():
+            self._pending_select_frames = None
+            self._select_frames_worker = None
+
+            if exc := future.exception():
+                if isinstance(exc, CancelledError):
+                    logger.info("Frame selection cancelled.")
+                else:
+                    logger.error("Error during frame selection: %s", exc)
+                self._update_buttons_state()
                 return
 
             times = future.result()
@@ -662,9 +686,9 @@ class CompPlugin(WidgetPluginBase[GlobalSettings, None], IconReloadMixin):
                     src_provider=src_provider,
                 )
 
-            self._pending_select_frames = None
             self._update_buttons_state()
 
+        self._select_frames_worker = worker
         self._pending_select_frames = worker.run()
         self._pending_select_frames.add_done_callback(on_finished)
         self._update_buttons_state()
@@ -676,14 +700,22 @@ class CompPlugin(WidgetPluginBase[GlobalSettings, None], IconReloadMixin):
                 return
 
             worker = ExtractFramesWorker(self.api, self)
+            self._extract_frames_worker = worker
             self._pending_extract_frames = worker.run()
 
             @run_in_loop
             def on_finished(f: Future[list[tuple[int, Path]]]) -> None:
                 self.clip_section.setEnabled(True)
                 self.progress_bar.reset_progress()
+                self.progress_stack.hide()
                 self._pending_extract_frames = None
-                if not f.exception():
+                self._extract_frames_worker = None
+                if exc := f.exception():
+                    if isinstance(exc, CancelledError):
+                        logger.info("Frame extraction cancelled.")
+                    else:
+                        logger.error("Error during frame extraction: %s", exc)
+                else:
                     self._extract_paths = f.result()
                     self._extraction_finished = True
                 self._update_buttons_state()
@@ -878,15 +910,16 @@ class CompPlugin(WidgetPluginBase[GlobalSettings, None], IconReloadMixin):
             return
 
         # Run the upload
+        self._is_upload_cancelled = False
 
         @run_in_loop
         def on_cookies(future: Future[dict[str, str]]) -> None:
-            if future.exception():
+            if self._is_upload_cancelled or future.exception():
                 self._on_upload_error()
                 return
 
             # Once we have the cookies, run the upload
-            self._pending_upload = self.slowpics_worker.upload(
+            src = SlowPicsSources(
                 collection_name=self.collection_name.text() or "Untitled",
                 sources=sources,
                 public=self.public_check.isChecked(),
@@ -894,16 +927,22 @@ class CompPlugin(WidgetPluginBase[GlobalSettings, None], IconReloadMixin):
                 tmdb_id=f"{self.tmdb_title.media_tag}_{self.tmdb_title.id}" if self.tmdb_title else None,
                 remove_after=self.remove_after.value(),
                 tags=self.tags.selected_tags(),
-                cookies=future.result(),
             )
+            self._pending_upload = self.slowpics_worker.upload(src=src, cookies=future.result())
 
             # Once the upload is finished, reset the progress bar and update the buttons state
             @run_in_loop
             def on_upload_finished(f: Future[str]) -> None:
                 self.progress_bar.reset_progress()
+                self.progress_stack.hide()
                 self._pending_upload = None
 
-                if not f.exception():
+                if exc := f.exception():
+                    if isinstance(exc, asyncio.CancelledError):
+                        logger.info("Upload cancelled.")
+                    else:
+                        logger.error("Error during upload: %s", exc)
+                else:
                     url = f.result()
                     logger.info("Upload complete: %s", url)
                     self._reported_url = url
@@ -923,6 +962,7 @@ class CompPlugin(WidgetPluginBase[GlobalSettings, None], IconReloadMixin):
     def _on_upload_error(self, message: str | None = None) -> None:
         # Helper to cleanup UI on failure from background
         self.progress_bar.reset_progress()
+        self.progress_stack.hide()
         self.clip_section.setEnabled(True)
         self._pending_upload = None
         self._update_buttons_state()
@@ -953,6 +993,17 @@ class CompPlugin(WidgetPluginBase[GlobalSettings, None], IconReloadMixin):
         self.upload_btn.setEnabled(frames_ready and not needs_extraction)
 
         self._current_outputs = current_outputs
+
+    def on_cancel_clicked(self) -> None:
+        logger.info("Cancel button clicked, aborting active tasks...")
+        if self._pending_select_frames and not self._pending_select_frames.done() and self._select_frames_worker:
+            self._select_frames_worker.cancel()
+        if self._pending_extract_frames and not self._pending_extract_frames.done() and self._extract_frames_worker:
+            self._extract_frames_worker.cancel()
+        if self._pending_upload and not self._pending_upload.done():
+            self._is_upload_cancelled = True
+            self.slowpics_worker.cancel()
+        self.progress_stack.hide()
 
     def on_url_copy_btn_clicked(self) -> None:
         QApplication.clipboard().setText(self._reported_url)

--- a/src/plugins/comp/src/vsview_comp/worker.py
+++ b/src/plugins/comp/src/vsview_comp/worker.py
@@ -4,8 +4,9 @@ import asyncio
 import os
 import re
 import threading
-from collections.abc import Awaitable, Callable, Iterator, Mapping, Sequence
-from concurrent.futures import Future, wait
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from concurrent.futures import CancelledError, Future, wait
+from contextlib import suppress
 from datetime import UTC, datetime
 from http.cookiejar import CookieJar
 from itertools import chain
@@ -14,7 +15,6 @@ from operator import attrgetter
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
-import anyio
 import niquests
 import niquests.cookies
 from jetpytools import cachedproperty, ndigits
@@ -27,7 +27,7 @@ from vstools import DitherType, clip_data_gather, core, depth, get_prop, remap_f
 from vsview.api import Packer, PluginAPI, PluginSecrets, PluginSettings, Time, run_in_background
 
 from ._metadata import COOKIE_KEY, LOGIN_CONTEXT
-from .models import ComparisonSource, TMDBPayload, TMDBTitle, TMDBTitleData
+from .models import SlowPicsSources, SlowPicsUploadResponse, TMDBPayload, TMDBTitle, TMDBTitleData
 from .ui import FrameSourceProvider, ProgressBar
 from .utils import LogNiquestsErrors, get_random_number_interval, get_slowpics_headers
 
@@ -46,13 +46,28 @@ class ExtractFramesWorker:
         self.data = parent.frames_list.get_data()
         self.voutputs = parent.selected_voutputs
         self.packer = Packer(8)
+        self._is_cancelled = False
+        self._lock = threading.Lock()
 
         if not (storage := self.api.get_local_storage(parent)):
             raise NotImplementedError
         self.storage = storage
 
+    @property
+    def is_cancelled(self) -> bool:
+        with self._lock:
+            return self._is_cancelled
+
     @run_in_background(name="ExtractFrames")
     def run(self) -> list[tuple[int, Path]]:
+        with self.api.vs_context():
+            return self._extract()
+
+    def cancel(self) -> None:
+        with self._lock:
+            self._is_cancelled = True
+
+    def _extract(self) -> list[tuple[int, Path]]:
         self.progress_bar.update_progress(
             range=(0, len(self.data) * len(self.voutputs)),
             fmt="Extracting frames %v / %m",
@@ -72,6 +87,8 @@ class ExtractFramesWorker:
             is_fpng_available = hasattr(core, "fpng")
 
             for output in self.voutputs:
+                if self.is_cancelled:
+                    raise CancelledError("Extract frames cancelled")
                 images_path = path / f"({output.vs_index}) ({output.vs_name})"
                 images_path = sanitize_filepath(images_path, replacement_text="_")
                 images_path.mkdir(parents=True, exist_ok=True)
@@ -90,7 +107,10 @@ class ExtractFramesWorker:
                 workers.append(f)
 
             # Wait for workers to finish extracting
-            wait(workers)
+            while not all(w.done() for w in workers):
+                if self.is_cancelled:
+                    raise CancelledError("Extract frames cancelled")
+                wait(workers, timeout=0.1)
 
         return images_paths
 
@@ -100,8 +120,13 @@ class ExtractFramesWorker:
             clip = clip.fpng.Write(filename=str(path), compression=1, alpha=alpha)
             remapped = remap_frames(clip, frames)
 
+            def _progress(*_: Any) -> None:
+                if self.is_cancelled:
+                    raise CancelledError("Extract frames cancelled")
+                self.progress_bar.update_progress(increment=1)
+
             with open(os.devnull, "wb") as sink:
-                remapped.output(sink, progress_update=lambda *_: self.progress_bar.update_progress(increment=1))
+                remapped.output(sink, progress_update=_progress)
 
     @run_in_background(name="ExtractQt")
     def _qt_extract(self, clip: VideoNode, alpha: VideoNode | None, path: Path, frames: Sequence[int]) -> None:
@@ -113,6 +138,8 @@ class ExtractFramesWorker:
             workers = list[Future[None]]()
 
             for n, vs_frame in zip(frames, remapped.frames(close=True)):
+                if self.is_cancelled:
+                    break
                 sema.acquire()
                 qimage = self.packer.frame_to_qimage(vs_frame).copy()
                 f = self._qt_save(qimage, path.with_stem(path.stem % n))
@@ -123,6 +150,8 @@ class ExtractFramesWorker:
 
     @run_in_background(name="QtSave")
     def _qt_save(self, qimage: QImage, path: Path) -> None:
+        if self.is_cancelled:
+            return
         qimage.save(str(path), "PNG", 75)  # type: ignore[call-overload]
         self.progress_bar.update_progress(increment=1)
 
@@ -145,6 +174,7 @@ class SelectFrameWorker:
         self.light = parent.light_frame_count.value()
         self.normal = parent.random_frame_count.value() - self.dark - self.light
         self.voutputs = parent.selected_voutputs
+        self.is_cancelled = False
 
         # Existing frames to avoid duplicates
         v = self.api.current_voutput
@@ -166,6 +196,9 @@ class SelectFrameWorker:
     def run(self) -> list[tuple[Time, FrameSourceProvider]]:
         with self.api.vs_context():
             return self.get()
+
+    def cancel(self) -> None:
+        self.is_cancelled = True
 
     def get(self) -> list[tuple[Time, FrameSourceProvider]]:
         found_times = list[tuple[Time, FrameSourceProvider]]()
@@ -198,6 +231,9 @@ class SelectFrameWorker:
             return random_frames
 
         while len(random_frames) < self.normal:
+            if self.is_cancelled:
+                raise CancelledError("Select frames cancelled")
+
             for _ in range(self.ALLOWED_FRAME_SEARCHES):
                 rnum = get_random_number_interval(
                     start_frame,
@@ -222,6 +258,8 @@ class SelectFrameWorker:
                     )
 
                     for f in node_frames.frames(close=True):
+                        if self.is_cancelled:
+                            raise CancelledError("Select frames cancelled")
                         is_pict_type_not_selected = (
                             self.should_check_pict
                             and get_prop(f, "_PictType", str, default="", func="__vsview__") not in self.pict_types
@@ -261,12 +299,10 @@ class SelectFrameWorker:
             range=(0, len(frames_to_check)), fmt="Checking frames light levels %v / %m", value=0
         )
 
-        checked_count = 0
-
         def _progress(*_: Any) -> None:
-            nonlocal checked_count
-            checked_count += 1
-            self.progress_bar.update_progress(value=checked_count)
+            if self.is_cancelled:
+                raise CancelledError("Select frames cancelled")
+            self.progress_bar.update_progress(increment=1)
 
         decimated = remap_frames(v.vs_output.clip, frames_to_check).std.PlaneStats()
         avg_levels = clip_data_gather(
@@ -401,6 +437,16 @@ class SlowPicsWorker:
         self.secrets = secrets
         self.progress_bar = progress_bar
         self.headers = get_slowpics_headers()
+        self.sema = asyncio.Semaphore(self.MAX_CONCURRENT_REQUESTS)
+        self.is_cancelled = False
+        self._upload_task: asyncio.Task[Any] | None = None
+        self._upload_loop: asyncio.AbstractEventLoop | None = None
+
+    def cancel(self) -> None:
+        self.is_cancelled = True
+        if self._upload_task and self._upload_loop:
+            with suppress(Exception):
+                self._upload_loop.call_soon_threadsafe(self._upload_task.cancel)
 
     @run_in_background(name="SlowPicsTags")
     def get_tags(self) -> list[Tag]:
@@ -438,102 +484,68 @@ class SlowPicsWorker:
             return self._cookies_jar(client.cookies) if await self._login_async(client) else {}
 
     @run_in_background(name="SlowPicsUpload")
-    async def upload(
-        self,
-        *,
-        collection_name: str,
-        sources: list[ComparisonSource],
-        public: bool,
-        nsfw: bool,
-        tmdb_id: str | None,
-        remove_after: int,
-        tags: list[str],
-        cookies: dict[str, str],
-    ) -> str:
-        self._sema = asyncio.Semaphore(self.MAX_CONCURRENT_REQUESTS)
+    async def upload(self, *, src: SlowPicsSources, cookies: dict[str, str]) -> str:
+        self.is_cancelled = False
+        self._upload_task = asyncio.current_task()
+        self._upload_loop = asyncio.get_running_loop()
 
-        is_comparison = len(sources) > 1
-        total_images = sum(len(images) for _, images in sources)
+        try:
+            async with (
+                niquests.AsyncSession(
+                    base_url=self.BASE_URL,
+                    pool_maxsize=self.MAX_CONCURRENT_REQUESTS,
+                    pool_connections=self.MAX_CONCURRENT_REQUESTS,
+                    headers=self.headers,
+                    cookies=cookies,
+                    timeout=20,
+                    disable_http3=True,
+                    multiplexed=True,
+                    revocation_configuration=REV_CONF,
+                ) as client,
+                LogNiquestsErrors("Slowpics Upload"),
+            ):
+                logger.debug("Setup client")
+                await self._setup_client(client, cookies)
 
-        async with (
-            niquests.AsyncSession(
-                base_url=self.BASE_URL,
-                pool_maxsize=self.MAX_CONCURRENT_REQUESTS,
-                pool_connections=self.MAX_CONCURRENT_REQUESTS,
-                headers=self.headers,
-                cookies=cookies,
-                timeout=20,
-                disable_http3=True,
-                multiplexed=True,
-                revocation_configuration=REV_CONF,
-            ) as client,
-            LogNiquestsErrors("Slowpics Upload"),
-        ):
-            await self._setup_client(client, cookies)
+                logger.debug("Starting upload of: %s", src.collection_name)
+                start_resp = await client.post(
+                    url=f"/upload/{src.upload_type}",
+                    data=src.payload | {"browserId": self.settings.global_.browser_id},
+                )
+                await client.gather(start_resp)
+                comp_data = SlowPicsUploadResponse.model_validate(start_resp.raise_for_status().json())
 
-            payload = {
-                "collectionName": collection_name or "",
-                "browserId": self.settings.global_.browser_id,
-                "optimizeImages": "true",
-                "desiredFileType": "image/png",
-                "hentai": str(nsfw).lower(),
-                "public": str(public).lower(),
-                "visibility": "PUBLIC" if public else "LINK_ONLY",
-                "removeAfter": str(remove_after) if remove_after >= 1 else "",
-            }
+                collection_url = f"https://slow.pics/c/{comp_data.key}"
+                logger.debug("Starting upload of: %s", collection_url)
 
-            for j in range(len(sources[0].images)):
-                if is_comparison:
-                    image_ref = sources[0][1][j]
-                    payload[f"comparisons[{j}].name"] = f"{image_ref.timestamp} / {image_ref.frame_no}"
-                    payload[f"comparisons[{j}].hentai"] = str(nsfw).lower()
+                # Upload images concurrently
+                self.progress_bar.update_progress(range=(0, src.total_images), fmt="Uploading images %v / %m", value=0)
 
-                    for i, (source_name, images) in enumerate(sources):
-                        payload[f"comparisons[{j}].imageNames[{i}]"] = (
-                            f"{source_name}{f' ({images[j].pict_type})' if images[j].pict_type != '?' else ''}"
-                        )
-                else:
-                    # Single source collection
-                    source_name, images = sources[0]
-                    image = images[j]
-                    payload[f"imageNames[{j}]"] = f"{image.timestamp} / {image.frame_no} - {source_name}"
+                async def upload_with_progress(img_uuid: str, img_path: Path) -> None:
+                    if self.is_cancelled:
+                        raise asyncio.CancelledError("Slowpics upload cancelled")
+                    logger.debug("Uploading image: %s", img_uuid)
+                    await self._upload_image(client, comp_data.collection_uuid, img_uuid, img_path)
+                    logger.debug("Finished uploading image: %s", img_uuid)
+                    self.progress_bar.update_progress(increment=1)
 
-            if tag_data := ({f"tags[{i}]": tag for i, tag in enumerate(tags)} if public else {}):
-                payload |= tag_data
+                async with asyncio.TaskGroup() as tg:
+                    for img_uuid, image_path in src.get_images(comp_data):
+                        if self.is_cancelled:
+                            raise asyncio.CancelledError("Slowpics upload cancelled")
+                        tg.create_task(upload_with_progress(img_uuid, image_path))
 
-            if tmdb_id:
-                payload["tmdbId"] = tmdb_id
+                logger.debug("Finished uploading all images")
+                self.progress_bar.update_progress(fmt="Finished uploading %v images")
 
-            endpoint = f"/upload/{'comparison' if is_comparison else 'collection'}"
-            start_resp = await client.post(endpoint, data=payload)
-            await client.gather(start_resp)
-            comp_data = start_resp.raise_for_status().json()
+                # Refresh cookies
+                self.secrets.set_json(COOKIE_KEY, COOKIE_KEY, self._cookies_jar(client.cookies))
+                logger.debug("Refreshed cookies")
 
-            collection_uuid = comp_data["collectionUuid"]
-            key = comp_data["key"]
-            image_ids: list[list[str]] = comp_data["images"]
-
-            logger.debug("Starting upload of: https://slow.pics/c/%s", key)
-
-            # Upload images concurrently
-            self.progress_bar.update_progress(range=(0, total_images), fmt="Uploading images %v / %m", value=0)
-            reqs = list[Awaitable[None]]()
-
-            for i, (_, images) in enumerate(sources):
-                for j, (image_path, *_) in enumerate(images):
-                    image_uuid = image_ids[j][i] if is_comparison else image_ids[0][j]
-                    reqs.append(self._upload_image(client, collection_uuid, image_uuid, image_path))
-
-            for i, coro in enumerate(asyncio.as_completed(reqs), start=1):
-                await coro
-                self.progress_bar.update_progress(value=i)
-
-            self.progress_bar.update_progress(fmt="Finished uploading %v images")
-
-            # Refresh cookies
-            self.secrets.set_json(COOKIE_KEY, COOKIE_KEY, self._cookies_jar(client.cookies))
-
-            return f"https://slow.pics/c/{key}"
+                return collection_url
+        finally:
+            self._upload_task = None
+            self._upload_loop = None
 
     async def _setup_client(self, client: niquests.AsyncSession, cookies: dict[str, str]) -> None:
         homepage = await client.get("/comparison")
@@ -612,12 +624,14 @@ class SlowPicsWorker:
 
         # Handle 429 "Too many requests"
         for retry in range(5):
+            if self.is_cancelled:
+                raise asyncio.CancelledError("Slowpics upload cancelled")
             try:
-                async with self._sema:
+                async with self.sema:
                     response = await client.post(
                         url,
                         data=data,
-                        files={"file": (image_path.name, await anyio.Path(image_path).read_bytes(), "image/png")},
+                        files={"file": (image_path.name, await asyncio.to_thread(image_path.read_bytes), "image/png")},
                     )
                     await client.gather(response)
                 if response.status_code == 429:

--- a/uv.lock
+++ b/uv.lock
@@ -37,19 +37,6 @@ wheels = [
 ]
 
 [[package]]
-name = "anyio"
-version = "4.13.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "idna" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
-]
-
-[[package]]
 name = "ast-serialize"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -453,15 +440,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/63/4c/8717ccb844b4fa5a5ba6352e97d743ed24e9a22cf90b7c109c17030a46a1/hatchling-1.30.1.tar.gz", hash = "sha256:eee4fd45357f72ebb3d7a42e5d72cfb5e29ed426d79e8836288926c4258d5f2e", size = 56929, upload-time = "2026-06-02T00:09:41.487Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/49/2797ec0ef88008a653a8867bb8d1e5c223cd2df8e40390dd5c6a0279cbc5/hatchling-1.30.1-py3-none-any.whl", hash = "sha256:161eacafb3c6f91526e92116d21426369f2c36e98c36a864f11a96345ad4ee31", size = 77489, upload-time = "2026-06-02T00:09:40.139Z" },
-]
-
-[[package]]
-name = "idna"
-version = "3.18"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -2280,7 +2258,6 @@ dev = [
 name = "vsview-comp"
 source = { editable = "src/plugins/comp" }
 dependencies = [
-    { name = "anyio" },
     { name = "jinja2" },
     { name = "niquests" },
     { name = "pathvalidate" },
@@ -2295,7 +2272,6 @@ vsfpng = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anyio", specifier = ">=4.12.1" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "niquests", specifier = ">=3.19.0" },
     { name = "pathvalidate", specifier = ">=3.3.1" },


### PR DESCRIPTION
Known issue:
- When cancelling a frame selection worker during the frame levels checks, the cancellation works but reports a leaked `vapoursynth.Error`.  https://github.com/vapoursynth/vapoursynth/pull/1220