### PR TITLE
fix: Fix images default display type

### DIFF
--- a/src/plugins/comp/src/vsview_comp/models.py
+++ b/src/plugins/comp/src/vsview_comp/models.py
@@ -55,6 +55,8 @@ class SlowPicsSources(NamedTuple):
             "public": str(self.public).lower(),
             "visibility": "PUBLIC" if self.public else "LINK_ONLY",
             "removeAfter": str(self.remove_after) if self.remove_after >= 1 else "",
+            "canvasMode": "none",
+            "imageFit": "none",
         }
 
         for j in range(len(self.sources[0].images)):
@@ -64,7 +66,7 @@ class SlowPicsSources(NamedTuple):
                 payload[f"comparisons[{j}].hentai"] = str(self.nsfw).lower()
 
                 for i, (source_name, images) in enumerate(self.sources):
-                    payload[f"comparisons[{j}].imageNames[{i}]"] = (
+                    payload[f"comparisons[{j}].images[{i}].name"] = (
                         f"{source_name}{f' ({images[j].pict_type})' if images[j].pict_type != '?' else ''}"
                     )
             else:


### PR DESCRIPTION
Without canvas and image fit set to none it will default to fit into canvas which will stretch the image. This sets it to default to show the images is it is.