### PR TITLE
feat: Support slow.pics hashSum field

### DIFF
--- a/src/plugins/comp/src/vsview_comp/models.py
+++ b/src/plugins/comp/src/vsview_comp/models.py
@@ -55,9 +55,13 @@ class SlowPicsSources(NamedTuple):
             "public": str(self.public).lower(),
             "visibility": "PUBLIC" if self.public else "LINK_ONLY",
             "removeAfter": str(self.remove_after) if self.remove_after >= 1 else "",
-            "canvasMode": "none",
-            "imageFit": "none",
         }
+
+        if self.is_comparison:
+            payload |= {
+                "canvasMode": "none",
+                "imageFit": "none",
+            }
 
         for j in range(len(self.sources[0].images)):
             if self.is_comparison:
@@ -73,7 +77,7 @@ class SlowPicsSources(NamedTuple):
                 # Single source collection
                 source_name, images = self.sources[0]
                 image = images[j]
-                payload[f"imageNames[{j}]"] = f"{image.timestamp} / {image.frame_no} - {source_name}"
+                payload[f"images[{j}].name"] = f"{image.timestamp} / {image.frame_no} - {source_name}"
 
         if self.public:
             payload |= {f"tags[{i}]": tag for i, tag in enumerate(self.tags)}
@@ -86,7 +90,8 @@ class SlowPicsSources(NamedTuple):
     def get_images(self, comp_data: SlowPicsUploadResponse) -> Iterator[tuple[str, Path]]:
         for i, (_, images) in enumerate(self.sources):
             for j, (image_path, *_) in enumerate(images):
-                yield comp_data.images[j][i] if self.is_comparison else comp_data.images[0][j], image_path
+                if ((image_uuid := comp_data.images[j][i] if self.is_comparison else comp_data.images[0][j]) not in comp_data.complete_image_uuids):
+                    yield image_uuid, image_path
 
 
 class SlowPicsUploadResponse(BaseModel):
@@ -95,6 +100,7 @@ class SlowPicsUploadResponse(BaseModel):
     collection_uuid: str = Field(alias="collectionUuid")
     key: str
     images: list[list[str]]
+    complete_image_uuids: list[str] = Field(alias="completeImageUuids")
 
 
 class TMDBGenre(BaseModel):

--- a/src/plugins/comp/src/vsview_comp/models.py
+++ b/src/plugins/comp/src/vsview_comp/models.py
@@ -84,8 +84,8 @@ class SlowPicsSources(NamedTuple):
     def get_images(self, comp_data: SlowPicsUploadResponse) -> Iterator[tuple[str, Path]]:
         for i, (_, images) in enumerate(self.sources):
             for j, (image_path, *_) in enumerate(images):
-                image_uuid =  comp_data.images[j][i] if self.is_comparison else comp_data.images[0][j]
-                if (image_uuid not in comp_data.complete_image_uuids):
+                image_uuid = comp_data.images[j][i] if self.is_comparison else comp_data.images[0][j]
+                if image_uuid not in comp_data.complete_image_uuids:
                     yield image_uuid, image_path
 
 

--- a/src/plugins/comp/src/vsview_comp/models.py
+++ b/src/plugins/comp/src/vsview_comp/models.py
@@ -57,12 +57,6 @@ class SlowPicsSources(NamedTuple):
             "removeAfter": str(self.remove_after) if self.remove_after >= 1 else "",
         }
 
-        if self.is_comparison:
-            payload |= {
-                "canvasMode": "none",
-                "imageFit": "none",
-            }
-
         for j in range(len(self.sources[0].images)):
             if self.is_comparison:
                 image_ref = self.sources[0][1][j]
@@ -90,7 +84,8 @@ class SlowPicsSources(NamedTuple):
     def get_images(self, comp_data: SlowPicsUploadResponse) -> Iterator[tuple[str, Path]]:
         for i, (_, images) in enumerate(self.sources):
             for j, (image_path, *_) in enumerate(images):
-                if ((image_uuid := comp_data.images[j][i] if self.is_comparison else comp_data.images[0][j]) not in comp_data.complete_image_uuids):
+                image_uuid =  comp_data.images[j][i] if self.is_comparison else comp_data.images[0][j]
+                if (image_uuid not in comp_data.complete_image_uuids):
                     yield image_uuid, image_path
 
 

--- a/src/plugins/comp/src/vsview_comp/worker.py
+++ b/src/plugins/comp/src/vsview_comp/worker.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import random
 import re
 import threading
@@ -633,7 +634,7 @@ class SlowPicsWorker:
                 logger.debug("Starting upload of: %s", src.collection_name)
                 start_resp = await client.post(
                     url=f"/upload/{src.upload_type}",
-                    data=src.payload | {"browserId": self.settings.global_.browser_id},
+                    data=src.payload | {"browserId": self.settings.global_.browser_id} | await self._hash_images(src),
                 )
                 await client.gather(start_resp)
                 comp_data = SlowPicsUploadResponse.model_validate(start_resp.raise_for_status().json())
@@ -783,6 +784,27 @@ class SlowPicsWorker:
                 logger.error("Error uploading %s (attempt %d) '%s'", image_path.name, retry + 1, e)
                 logger.debug("Traceback:", exc_info=True)
                 await asyncio.sleep((retry + 1) * 2)
+
+    async def _hash_images(self, src: SlowPicsSources) -> dict[str, str]:
+        payload = {}
+
+        def _hash_image(file: Path, image_key: str) -> None:
+            with file.open("rb") as f:
+                payload[image_key] = hashlib.file_digest(f, "sha256").hexdigest()
+
+        hash_tasks = []
+        for j in range(len(src.sources[0].images)):
+            for i, (source_name, images) in enumerate(src.sources):
+                hash_tasks.append(
+                    asyncio.to_thread(
+                        _hash_image,
+                        images[j].path,
+                        f"comparisons[{j}].images[{i}].hashSum" if src.is_comparison else f"images[{j}].hashSum",
+                    )
+                )
+
+        await asyncio.gather(*hash_tasks)
+        return payload
 
     @staticmethod
     def _cookies_jar(cookies: CookieJar) -> dict[str, str]:

--- a/src/plugins/comp/src/vsview_comp/worker.py
+++ b/src/plugins/comp/src/vsview_comp/worker.py
@@ -631,10 +631,13 @@ class SlowPicsWorker:
                 logger.debug("Setup client")
                 await self._setup_client(client, cookies)
 
+                logger.debug("Calculating image hashes")
+                image_hashes = await self._hash_images(src)
+
                 logger.debug("Starting upload of: %s", src.collection_name)
                 start_resp = await client.post(
                     url=f"/upload/{src.upload_type}",
-                    data=src.payload | {"browserId": self.settings.global_.browser_id} | await self._hash_images(src),
+                    data=src.payload | {"browserId": self.settings.global_.browser_id} | image_hashes,
                 )
                 await client.gather(start_resp)
                 comp_data = SlowPicsUploadResponse.model_validate(start_resp.raise_for_status().json())
@@ -786,24 +789,23 @@ class SlowPicsWorker:
                 await asyncio.sleep((retry + 1) * 2)
 
     async def _hash_images(self, src: SlowPicsSources) -> dict[str, str]:
-        payload = {}
+        payload = dict[str, str]()
 
         def _hash_image(file: Path, image_key: str) -> None:
             with file.open("rb") as f:
                 payload[image_key] = hashlib.file_digest(f, "sha256").hexdigest()
 
-        hash_tasks = []
-        for j in range(len(src.sources[0].images)):
-            for i, (source_name, images) in enumerate(src.sources):
-                hash_tasks.append(
-                    asyncio.to_thread(
-                        _hash_image,
-                        images[j].path,
-                        f"comparisons[{j}].images[{i}].hashSum" if src.is_comparison else f"images[{j}].hashSum",
+        async with asyncio.TaskGroup() as tg:
+            for j in range(len(src.sources[0].images)):
+                for i, (_, images) in enumerate(src.sources):
+                    tg.create_task(
+                        asyncio.to_thread(
+                            _hash_image,
+                            images[j].path,
+                            f"comparisons[{j}].images[{i}].hashSum" if src.is_comparison else f"images[{j}].hashSum",
+                        )
                     )
-                )
 
-        await asyncio.gather(*hash_tasks)
         return payload
 
     @staticmethod


### PR DESCRIPTION
Generates a hash of the image during the request to make the comp, if the image already exists, it will be returned in the response saying it already exists. We just need to skip these uploads.