### PR TITLE
Fix issues with SAR display

### DIFF
--- a/src/vsview/app/views/video.py
+++ b/src/vsview/app/views/video.py
@@ -748,7 +748,7 @@ class BaseGraphicsView(QGraphicsView):
             return
 
         self._sar = sar
-        has_sar = isclose(sar, 1.0)
+        has_sar = not isclose(sar, 1.0)
 
         if self.apply_sar_action.isEnabled() != has_sar:
             self.apply_sar_action.setEnabled(has_sar)

--- a/src/vsview/app/workspace/tab_manager.py
+++ b/src/vsview/app/workspace/tab_manager.py
@@ -357,7 +357,9 @@ class TabManager(QWidget, IconReloadMixin):
                 else QPixmap.fromImage(image, Qt.ImageConversionFlag.NoFormatConversion)
             )
             self.current_view.set_pixmap(pixmap, image if isinstance(image, QImage) else None)
-            self.current_view.set_sar(sar)
+
+            if sar is not None:
+                self.current_view.set_sar(sar)
         finally:
             if backing_frame:
                 backing_frame.close()


### PR DESCRIPTION
Toggle was disabled when SAR present ([ref](https://github.com/Jaded-Encoding-Thaumaturgy/vs-view/commit/29304ce80c18934c523c02177aa4a96a471f879c#diff-ef6b93076139b6aead8379ca2bd914f7b9e4d33019026c949d471cb87807bf74L628-R629))

Switching tabs was clearing/setting the SAR to 1.0 on calling `update_current_view` ([ref](https://github.com/Jaded-Encoding-Thaumaturgy/vs-view/blob/f89a9e5b0cb9af4b2e6788b9391d12e94b928bfd/src/vsview/app/workspace/loader.py#L633)), this would clear the checked state.  Not sure if this is the correct way to fix this.