### PR TITLE
fix: declare libxkbcommon ctypes signatures on Linux

### DIFF
--- a/src/vsview/app/settings/shortcuts.py
+++ b/src/vsview/app/settings/shortcuts.py
@@ -530,7 +530,7 @@ class KeyboardLayoutMapper(Singleton):
     @fallback_logged
     def _translate_linux(self, upper_base: str) -> str | None:
         xkb_path = ctypes.util.find_library("xkbcommon") or "libxkbcommon.so.0"
-        libxkb = ctypes.cdll.LoadLibrary(xkb_path)
+        libxkb = ctypes.CDLL(xkb_path)
 
         # Define function signatures so ctypes does not truncate opaque pointers to C ints.
         libxkb.xkb_context_new.argtypes = [ctypes.c_int]

--- a/src/vsview/app/settings/shortcuts.py
+++ b/src/vsview/app/settings/shortcuts.py
@@ -532,10 +532,27 @@ class KeyboardLayoutMapper(Singleton):
         xkb_path = ctypes.util.find_library("xkbcommon") or "libxkbcommon.so.0"
         libxkb = ctypes.cdll.LoadLibrary(xkb_path)
 
-        # Define function return types
+        # Define function signatures so ctypes does not truncate opaque pointers to C ints.
+        libxkb.xkb_context_new.argtypes = [ctypes.c_int]
         libxkb.xkb_context_new.restype = ctypes.c_void_p
+        libxkb.xkb_context_unref.argtypes = [ctypes.c_void_p]
+        libxkb.xkb_context_unref.restype = None
+
+        libxkb.xkb_keymap_new_from_names.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int]
         libxkb.xkb_keymap_new_from_names.restype = ctypes.c_void_p
+        libxkb.xkb_keymap_unref.argtypes = [ctypes.c_void_p]
+        libxkb.xkb_keymap_unref.restype = None
+
+        libxkb.xkb_state_new.argtypes = [ctypes.c_void_p]
         libxkb.xkb_state_new.restype = ctypes.c_void_p
+        libxkb.xkb_state_unref.argtypes = [ctypes.c_void_p]
+        libxkb.xkb_state_unref.restype = None
+        libxkb.xkb_state_key_get_utf8.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_uint32,
+            ctypes.POINTER(ctypes.c_char),
+            ctypes.c_size_t,
+        ]
         libxkb.xkb_state_key_get_utf8.restype = ctypes.c_int
 
         ctx = libxkb.xkb_context_new(0)

--- a/tests/test_keyboard_layout.py
+++ b/tests/test_keyboard_layout.py
@@ -259,6 +259,20 @@ def test_linux_ctypes_translation(monkeypatch: pytest.MonkeyPatch) -> None:
     )  # XKB_KEYMAP_COMPILE_NO_FLAGS = 0
     mock_libxkb.xkb_state_new.assert_called_once_with(MOCK_KEYMAP_PTR)
 
+    # ctypes otherwise assumes C int arguments, truncating opaque pointers on 64-bit platforms.
+    assert mock_libxkb.xkb_context_new.argtypes == [ctypes.c_int]
+    assert mock_libxkb.xkb_context_unref.argtypes == [ctypes.c_void_p]
+    assert mock_libxkb.xkb_keymap_new_from_names.argtypes == [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int]
+    assert mock_libxkb.xkb_keymap_unref.argtypes == [ctypes.c_void_p]
+    assert mock_libxkb.xkb_state_new.argtypes == [ctypes.c_void_p]
+    assert mock_libxkb.xkb_state_unref.argtypes == [ctypes.c_void_p]
+    assert mock_libxkb.xkb_state_key_get_utf8.argtypes == [
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+        ctypes.POINTER(ctypes.c_char),
+        ctypes.c_size_t,
+    ]
+
     # Verify C resource cleanup (unref calls)
     mock_libxkb.xkb_state_unref.assert_called_once_with(MOCK_STATE_PTR)
     mock_libxkb.xkb_keymap_unref.assert_called_once_with(MOCK_KEYMAP_PTR)

--- a/tests/test_keyboard_layout.py
+++ b/tests/test_keyboard_layout.py
@@ -233,7 +233,7 @@ def test_linux_ctypes_translation(monkeypatch: pytest.MonkeyPatch) -> None:
     EVDEV_OFFSET = 8
 
     mock_libxkb = MagicMock()
-    monkeypatch.setattr(ctypes.cdll, "LoadLibrary", lambda path: mock_libxkb)
+    monkeypatch.setattr(ctypes, "CDLL", lambda path: mock_libxkb)
 
     mock_libxkb.xkb_context_new.return_value = MOCK_CTX_PTR
     mock_libxkb.xkb_keymap_new_from_names.return_value = MOCK_KEYMAP_PTR
@@ -282,7 +282,7 @@ def test_linux_ctypes_translation(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_linux_ctypes_failures_and_cleanup(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sys, "platform", "linux")
     mock_libxkb = MagicMock()
-    monkeypatch.setattr(ctypes.cdll, "LoadLibrary", lambda path: mock_libxkb)
+    monkeypatch.setattr(ctypes, "CDLL", lambda path: mock_libxkb)
 
     MOCK_CTX_PTR = 100
     MOCK_KEYMAP_PTR = 200


### PR DESCRIPTION
## Summary

- declare complete ctypes signatures for the libxkbcommon functions used by Linux keyboard layout translation
- preserve opaque pointer widths and model void-returning cleanup functions correctly
- extend the existing Linux keyboard layout test to assert the native argument types

## Problem

Without `argtypes`, ctypes assumes C `int` arguments. On 64-bit Linux, this truncates the context pointer returned by `xkb_context_new` when it is passed to `xkb_keymap_new_from_names`, causing a SIGSEGV inside `xkb_context_ref` while VSView initializes shortcuts.

## Testing

- `QT_QPA_PLATFORM=offscreen uv run --frozen --no-sync pytest tests -q` (`92 passed`)
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check --diff`
- `.venv/bin/mypy src/vsview/app/settings/shortcuts.py tests/test_keyboard_layout.py`
- 1,000 consecutive native libxkbcommon translations
- manual startup with a real VapourSynth script; content loaded successfully and VSView remained running without a segmentation fault
