### PR TITLE
Use explicit arg/restypes for Carbon C lib use on macOS

### DIFF
--- a/src/vsview/app/settings/shortcuts.py
+++ b/src/vsview/app/settings/shortcuts.py
@@ -490,7 +490,28 @@ class KeyboardLayoutMapper(Singleton):
         if upper_base not in MACOS_KEYCODES or not (carbon_path := ctypes.util.find_library("Carbon")):
             return None
 
-        carbon = ctypes.cdll.LoadLibrary(carbon_path)
+        carbon = ctypes.CDLL(carbon_path)
+        carbon.TISCopyCurrentKeyboardInputSource.restype = ctypes.c_void_p
+        carbon.TISGetInputSourceProperty.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+        carbon.TISGetInputSourceProperty.restype = ctypes.c_void_p
+        carbon.UCKeyTranslate.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_uint16,
+            ctypes.c_uint16,
+            ctypes.c_uint32,
+            ctypes.c_uint32,
+            ctypes.c_uint32,
+            ctypes.c_void_p,
+            ctypes.c_uint32,
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+        ]
+        carbon.UCKeyTranslate.restype = ctypes.c_int32
+        # CoreFoundation symbols resolve through the Carbon handle
+        carbon.CFDataGetBytePtr.argtypes = [ctypes.c_void_p]
+        carbon.CFDataGetBytePtr.restype = ctypes.c_void_p
+        carbon.CFRelease.argtypes = [ctypes.c_void_p]
+        carbon.CFRelease.restype = None
         mac_keycode = MACOS_KEYCODES[upper_base]
 
         # Get current keyboard input source layout data pointer
@@ -499,10 +520,13 @@ class KeyboardLayoutMapper(Singleton):
             return None
 
         # kTISPropertyUnicodeKeyLayoutData = "TISPropertyUnicodeKeyLayoutData"
-        layout_data_ptr = carbon.TISGetInputSourceProperty(
+        # The property is a CFDataRef wrapping the UCKeyboardLayout bytes
+        layout_data = carbon.TISGetInputSourceProperty(
             tis_source, ctypes.c_void_p.in_dll(carbon, "kTISPropertyUnicodeKeyLayoutData")
         )
+        layout_data_ptr = carbon.CFDataGetBytePtr(layout_data) if layout_data else None
         if not layout_data_ptr:
+            carbon.CFRelease(tis_source)
             return None
 
         buf = ctypes.create_unicode_buffer(4)
@@ -510,18 +534,22 @@ class KeyboardLayoutMapper(Singleton):
         dead_key_state = ctypes.c_uint32(0)
 
         # UCKeyTranslate(layout_data, keycode, action, modifiers, keyboard_type, options, state, max_len, len, buf)
-        res = carbon.UCKeyTranslate(
-            layout_data_ptr,
-            ctypes.c_uint16(mac_keycode),
-            ctypes.c_uint16(0),  # kUCKeyActionDisplay
-            ctypes.c_uint32(0),  # no modifiers
-            ctypes.c_uint32(0),  # LMGetKbdType()
-            ctypes.c_uint32(0),  # kUCKeyTranslateNoDeadKeysBit
-            ctypes.byref(dead_key_state),
-            ctypes.c_uint32(4),
-            ctypes.byref(length),
-            buf,
-        )
+        try:
+            res = carbon.UCKeyTranslate(
+                layout_data_ptr,
+                ctypes.c_uint16(mac_keycode),
+                ctypes.c_uint16(0),  # kUCKeyActionDisplay
+                ctypes.c_uint32(0),  # no modifiers
+                ctypes.c_uint32(0),  # LMGetKbdType()
+                ctypes.c_uint32(0),  # kUCKeyTranslateNoDeadKeysBit
+                ctypes.byref(dead_key_state),
+                ctypes.c_uint32(4),
+                ctypes.byref(length),
+                buf,
+            )
+        finally:
+            # layout_data is owned by the source, so release it
+            carbon.CFRelease(tis_source)
         if res == 0 and length.value > 0 and buf.value:
             return buf.value
 

--- a/tests/test_keyboard_layout.py
+++ b/tests/test_keyboard_layout.py
@@ -146,8 +146,8 @@ def test_darwin_ctypes_translation(monkeypatch: pytest.MonkeyPatch) -> None:
 
     mock_carbon = MagicMock()
     monkeypatch.setattr(
-        ctypes.cdll,
-        "LoadLibrary",
+        ctypes,
+        "CDLL",
         lambda path: mock_carbon if path == "/System/Library/Frameworks/Carbon.framework/Carbon" else MagicMock(),
     )
     monkeypatch.setattr(ctypes.c_void_p, "in_dll", lambda lib, name: ctypes.c_void_p(MOCK_LAYOUT_DATA_PTR))
@@ -181,6 +181,30 @@ def test_darwin_ctypes_translation(monkeypatch: pytest.MonkeyPatch) -> None:
     translated = mapper.translate_qwerty_to_active(QKeySequence("Ctrl+A"))
     assert translated == QKeySequence("Ctrl+Q")
     mock_carbon.TISCopyCurrentKeyboardInputSource.assert_called_once()
+    mock_carbon.CFDataGetBytePtr.assert_called_once_with(MOCK_PROP_DATA)
+    mock_carbon.CFRelease.assert_called_once_with(MOCK_TIS_SOURCE)
+
+    # ctypes otherwise assumes C int returns/arguments, truncating opaque pointers on 64-bit platforms.
+    assert mock_carbon.TISCopyCurrentKeyboardInputSource.restype == ctypes.c_void_p
+    assert mock_carbon.TISGetInputSourceProperty.argtypes == [ctypes.c_void_p, ctypes.c_void_p]
+    assert mock_carbon.TISGetInputSourceProperty.restype == ctypes.c_void_p
+    assert mock_carbon.UCKeyTranslate.argtypes == [
+        ctypes.c_void_p,
+        ctypes.c_uint16,
+        ctypes.c_uint16,
+        ctypes.c_uint32,
+        ctypes.c_uint32,
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+    ]
+    assert mock_carbon.UCKeyTranslate.restype == ctypes.c_int32
+    assert mock_carbon.CFDataGetBytePtr.argtypes == [ctypes.c_void_p]
+    assert mock_carbon.CFDataGetBytePtr.restype == ctypes.c_void_p
+    assert mock_carbon.CFRelease.argtypes == [ctypes.c_void_p]
+    assert mock_carbon.CFRelease.restype is None
 
 
 def test_darwin_ctypes_failures(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -202,7 +226,7 @@ def test_darwin_ctypes_failures(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(ctypes.util, "find_library", lambda lib: "/path/to/Carbon")
     mock_carbon = MagicMock()
     mock_carbon.TISCopyCurrentKeyboardInputSource.return_value = 0
-    monkeypatch.setattr(ctypes.cdll, "LoadLibrary", lambda path: mock_carbon)
+    monkeypatch.setattr(ctypes, "CDLL", lambda path: mock_carbon)
 
     assert mapper.translate_qwerty_to_active(QKeySequence("Ctrl+A")) == QKeySequence("Ctrl+A")
     mapper._cache.clear()


### PR DESCRIPTION
ctypes defaults restype to c_int, so the 64-bit `TISInputSourceRef` was chopped to its low 32 bits before being handed back to Carbon. This also switches to CDLL like was done for Linux, which is the norm for explicit typed signature.

@gdd00 already fixed this for 64-bit Linux in Jaded-Encoding-Thaumaturgy/vs-view#198. For consistency, I perform a similar unit test as was added for Linux.

Fixes Jaded-Encoding-Thaumaturgy/vs-view#200.