### PR TITLE
view: add full-name tooltips to output tabs

### DIFF
--- a/src/vsview/app/views/tab.py
+++ b/src/vsview/app/views/tab.py
@@ -227,5 +227,7 @@ class TabLabel(QWidget):
             metrics.elidedText(name_text, Qt.TextElideMode.ElideRight, self._name_label.maximumWidth())
         )
 
+        self.setToolTip(name_text)
+
     def _update_zoom_text(self) -> None:
         self._zoom_label.setText(f"({round(self._zoom * 100)}%)" if self._zoom else "(---%)")


### PR DESCRIPTION
Show a tooltip with the full name when hovering a tab.